### PR TITLE
Minor fixes in demos

### DIFF
--- a/demo/demo1_calibration.py
+++ b/demo/demo1_calibration.py
@@ -17,7 +17,7 @@ CALIPOINTS = [(x * DISPSIZE[0], y * DISPSIZE[1]) for x, y in CALINORMP]
 # The number of stimuli must be the same or larger than the calibration points.
 CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
-    if '.png' in x
+    if x.endswith('.png') and not x.startswith('.')
 ]
 
 ###############################################################################

--- a/demo/demo2_collect_looking_time.py
+++ b/demo/demo2_collect_looking_time.py
@@ -16,7 +16,7 @@ CALIPOINTS = [(x * DISPSIZE[0], y * DISPSIZE[1]) for x, y in CALINORMP]
 # correct path for calibration stimuli
 CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
-    if '.png' in x
+    if x.endswith('.png') and not x.startswith('.')
 ]
 
 ###############################################################################

--- a/demo/demo3_collect_looking_time_with_video.py
+++ b/demo/demo3_collect_looking_time_with_video.py
@@ -16,7 +16,7 @@ CALIPOINTS = [(x * DISPSIZE[0], y * DISPSIZE[1]) for x, y in CALINORMP]
 # correct path for calibration stimuli
 CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
-    if '.png' in x
+    if x.endswith('.png') and not x.startswith('.')
 ]
 
 ###############################################################################

--- a/demo/demo5_customized_calibration.py
+++ b/demo/demo5_customized_calibration.py
@@ -18,7 +18,7 @@ CALIPOINTS = [(x * DISPSIZE[0], y * DISPSIZE[1]) for x, y in CALINORMP]
 # The number of stimuli must be the same or larger than the calibration points.
 CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
-    if '.png' in x
+    if x.endswith('.png') and not x.startswith('.')
 ]
 SOUNDSTIM = 'infant/wawa.wav'
 

--- a/demo/demo5_customized_calibration.py
+++ b/demo/demo5_customized_calibration.py
@@ -40,6 +40,7 @@ grabber = visual.MovieStim3(win, "infant/seal-clip.mp4")
 # create a customized calibration procedure with sound
 # code snippets copied from _update_calibration_infant()
 def customized_update_calibration(self,
+                                  _focus_time=0.5,
                                   collect_key='space',
                                   exit_key='return'):
     # start calibration
@@ -60,7 +61,7 @@ def customized_update_calibration(self,
                 # -- Modification end --
             elif key == collect_key:
                 # allow the participant to focus
-                core.wait(0.5)
+                core.wait(_focus_time)
                 # collect samples when space is pressed
                 if current_point_index in self.retry_points:
                     self._collect_calibration_data(

--- a/demo/demo6_calibration_with_sound.py
+++ b/demo/demo6_calibration_with_sound.py
@@ -17,7 +17,7 @@ CALIPOINTS = [(x * DISPSIZE[0], y * DISPSIZE[1]) for x, y in CALINORMP]
 # The number of stimuli must be the same or larger than the calibration points.
 CALISTIMS = [
     'infant/{}'.format(x) for x in os.listdir(os.path.join(DIR, 'infant'))
-    if '.png' in x
+    if x.endswith('.png') and not x.startswith('.')
 ]
 SOUNDSTIM = 'infant/wawa.wav'
 


### PR DESCRIPTION
(This project seems really cool, thanks for sharing it!)

The first commit in this PR makes demos ignore all hidden .png files in the 'infant' directory. This is important for some OS's (it happened to me when running the experiment on Windows), where temporary files like '._pig.png' might be created. Without the check, these temporary files cause fatal errors when running the task. Also, rather than using `in`, `endswith` is now used for checking the 'png' file extension, since this is more specific and expressive.

The second commit fixes a specific bug in the code for demo5. Before, running demo5 caused an error related to the custom `update_calibration` method, since it didn't accept a `_focus_time` argument. I'm guessing that this parameter was added to the TobiiController's methods some time after demo5 had been created.